### PR TITLE
Xcode files with xcode9.3

### DIFF
--- a/ShiftOperations.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ShiftOperations.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
With Xcode9.3, If I change `Show` checkbox on scheme management window,
Xcode make a this file.

I use this library by gitsubmodule + carthage and add xcodeproj to xcworkspace for application development.
So this diff makes work repository state dirty.
Please merge this.

It similar to https://github.com/nvzqz/RandomKit/pull/57